### PR TITLE
fixed markdown image code

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Boxed will try its best to figure out the publication date and title from the ma
 
 ### Images
 
-Boxed supports images out of the box, you have to put them in the ```images``` folder, and then reference them like: ```![cool image](../images/image.jpeg")```
+Boxed supports images out of the box, you have to put them in the ```images``` folder, and then reference them like: ```![cool image](../images/image.jpeg "Cool image")```
 
 
 ### Template customization


### PR DESCRIPTION
Just fixing the image code in markdown language: according to http://daringfireball.net/projects/markdown/syntax#img, the double quotes (") are used to set the title :smile:
